### PR TITLE
fix: adjust global.json SDK roll-forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "version": "8.0.200",
-        "rollForward": "latestPatch",
+        "rollForward": "latestFeature",
         "allowPrerelease": false
     }
 }


### PR DESCRIPTION
Keep requested SDK version 8.0.200 and enable latestFeature roll-forward so installed .NET 8 feature bands (e.g. 8.0.418) resolve correctly.